### PR TITLE
Documentation update for certificate request and long poll api changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ This method is necessary for *AdES-styled digital signatures which require knowl
 
 ### <span class="numhead-number">4.1.2\.</span> Postconditions
 
-*   New session has been created in the system and its ID returned in response. 
+*   Request result has been returned to user. 
 
 ### <span class="numhead-number">4.1.3\.</span> Request parameters
 
@@ -367,7 +367,8 @@ _`}`_
 <td class="confluenceTd">
 
 _`{`_  
-_`"sessionID": "de305d54-75b4-431b-adb2-eb6b9e546015"`_  
+_`"result": "OK",`_  
+_`"cert": "MIIHhjCCBW6gAwIBAgIQDNYLtVwrKURYStrYApYViTANBgkqhkiG9w0B..."`_  
 _`}`_
 
 </td>
@@ -380,7 +381,77 @@ _`}`_
 
 </div>
 
-### <span class="numhead-number">4.1.6\.</span> Error conditions
+### <span class="numhead-number">4.1.6\.</span> Response structure 
+
+<div class="table-wrap">
+
+<table class="confluenceTable"><colgroup><col> <col> <col> <col></colgroup> 
+
+<thead>
+
+<tr>
+
+<th class="confluenceTh">
+
+Parameter
+
+</th>
+
+<th class="confluenceTh">
+
+Type
+
+</th>
+
+<th class="confluenceTh">
+
+Mandatory
+
+</th>
+
+<th class="confluenceTh">
+
+Description
+
+</th>
+
+</tr>
+
+</thead>
+
+<tbody>
+
+<tr>
+
+<td class="confluenceTd">result</td>
+
+<td class="confluenceTd">string</td>
+
+<td class="confluenceTd">+</td>
+
+<td class="confluenceTd">End result of the transaction.</td>
+
+</tr>
+
+<tr>
+
+<td colspan="1" class="confluenceTd">cert</td>
+
+<td colspan="1" class="confluenceTd">string</td>
+
+<td colspan="1" class="confluenceTd">for OK result</td>
+
+<td colspan="1" class="confluenceTd">Certificate value, DER + Base64 encoded.</td>
+
+</tr>
+
+</tbody>
+
+</table>
+
+</div>
+
+### <span class="numhead-number">4.1.7\.</span> Error conditions
 
 <div class="table-wrap">
 
@@ -455,7 +526,7 @@ _`}`_
 
 </div>
 
-## <span class="numhead-number">4.2\.</span> Certificate request status
+### <span class="numhead-number">4.1.8\.</span> Possible result values
 
 <div class="table-wrap">
 
@@ -465,188 +536,7 @@ _`}`_
 
 <tr>
 
-<td class="confluenceTd">**Method**</td>
-
-<td class="confluenceTd">**URL**</td>
-
-</tr>
-
-<tr>
-
-<td colspan="1" class="confluenceTd"><span style="color: rgb(0,0,0);">GET</span></td>
-
-<td colspan="1" class="confluenceTd"><span class="nolink">BASE/certificate/session/:sessionId</span></td>
-
-</tr>
-
-</tbody>
-
-</table>
-
-</div>
-
-This method can be used to retrieve session result for certificate from MID.
-
-### <span class="numhead-number">4.2.1\.</span> Preconditions
-
-*   Session is present in the system and the request is either running or has been completed less than x minutes ago. 
-
-### <span class="numhead-number">4.2.2\.</span> Postconditions
-
-*   Request result has been returned to user. 
-
-### <span class="numhead-number">4.2.3\.</span> Response structure 
-
-<div class="table-wrap">
-
-<table class="confluenceTable"><colgroup><col> <col> <col> <col></colgroup> 
-
-<thead>
-
-<tr>
-
-<th class="confluenceTh">
-
-Parameter
-
-</th>
-
-<th class="confluenceTh">
-
-Type
-
-</th>
-
-<th class="confluenceTh">
-
-Mandatory
-
-</th>
-
-<th class="confluenceTh">
-
-Description
-
-</th>
-
-</tr>
-
-</thead>
-
-<tbody>
-
-<tr>
-
-<td class="confluenceTd">state</td>
-
-<td class="confluenceTd">string</td>
-
-<td class="confluenceTd">+</td>
-
-<td class="confluenceTd">State of request. "RUNNING"/"COMPLETE".</td>
-
-</tr>
-
-<tr>
-
-<td class="confluenceTd">result</td>
-
-<td class="confluenceTd">string</td>
-
-<td class="confluenceTd">+</td>
-
-<td class="confluenceTd">End result of the transaction.</td>
-
-</tr>
-
-<tr>
-
-<td colspan="1" class="confluenceTd">cert</td>
-
-<td colspan="1" class="confluenceTd">string</td>
-
-<td colspan="1" class="confluenceTd">for OK result</td>
-
-<td colspan="1" class="confluenceTd">Certificate value, DER + Base64 encoded.</td>
-
-</tr>
-
-</tbody>
-
-</table>
-
-</div>
-
-**successful response when still waiting for user's response**
-
-<div class="table-wrap">
-
-<table class="confluenceTable"><colgroup><col></colgroup> 
-
-<tbody>
-
-<tr>
-
-<td class="confluenceTd">
-
-_`{`_  
-_`"state"` `: ` `"RUNNING"` `,`_  
-_`"result"` `: {}`_  
-_`}`_
-
-</td>
-
-</tr>
-
-</tbody>
-
-</table>
-
-</div>
-
-<span style="color: rgb(0,0,0);"> </span>  
-**successful response after completion**
-
-<div class="table-wrap">
-
-<table class="relative-table confluenceTable" style="width: 38.75%;"><colgroup><col style="width: 100.0%;"></colgroup> 
-
-<tbody>
-
-<tr>
-
-<td class="confluenceTd">
-
-_`{`_
-
-_``"state"` `: ` `"COMPLETE";``_  
-_`"result"` `: "OK"` `,`_  
-_`"cert"` `:` `"B+C9XVjIAZnCHH9vfBSv..."`_  
-_`}`_
-
-</td>
-
-</tr>
-
-</tbody>
-
-</table>
-
-</div>
-
-### <span class="numhead-number">4.2.4\.</span> Error codes
-
-<div class="table-wrap">
-
-<table class="confluenceTable"><colgroup><col> <col> <col></colgroup> 
-
-<tbody>
-
-<tr>
-
-<th class="confluenceTh">Error code</th>
-
-<th class="confluenceTh">Error message</th>
+<th class="confluenceTh">Response</th>
 
 <th class="confluenceTh">Reason</th>
 
@@ -654,61 +544,35 @@ _`}`_
 
 <tr>
 
-<td class="confluenceTd">500</td>
+<td class="confluenceTd">OK</td>
 
-<td class="confluenceTd">Error retrieving certificate response</td>
-
-<td class="confluenceTd">Happens when getting session status from cert-store fails. Cert-store throws internal server error</td>
+<td class="confluenceTd"><span>Active certificate was found</span></td>
 
 </tr>
 
 <tr>
 
-<td class="confluenceTd">404</td>
+<td class="confluenceTd">NOT_FOUND</td>
 
-<td class="confluenceTd">SessionId not found :sessionID</td>
-
-<td class="confluenceTd">SessionID in request is not found</td>
+<td class="confluenceTd"><span>No certificate for the user was found</span></td>
 
 </tr>
 
 <tr>
 
-<td colspan="1" class="confluenceTd">400</td>
+<td colspan="1" class="confluenceTd">NOT_ACTIVE</td>
 
-<td colspan="1" class="confluenceTd">Required sessionId is missing :sessionID</td>
-
-<td colspan="1" class="confluenceTd">Happens when sessionID is missing.</td>
+<td colspan="1" class="confluenceTd"><span>Certificate was found but is not active</span></td>
 
 </tr>
 
-
-<tr>
-
-<td colspan="1" class="confluenceTd">401</td>
-
-<td colspan="1" class="confluenceTd">Failed to authorize user</td>
-
-<td colspan="1" class="confluenceTd">User authorization by sessionID and IP-address fails</td>
-
-</tr>
-
-<tr>
-
-<td colspan="1" class="confluenceTd">405</td>
-
-<td colspan="1" class="confluenceTd">Method Not Allowed</td>
-
-<td colspan="1" class="confluenceTd">  
-</td>
-
-</tr>
 
 </tbody>
 
 </table>
 
 </div>
+
 
 ## <span class="numhead-number">4.3\.</span> Signature request
 
@@ -1093,7 +957,15 @@ _`}`_
 
 </div>
 
-This method can be used to retrieve session result for authentication from MID.
+<strong>Query parameter</strong> timeoutMs Request long poll timeout value in milliseconds. If not provided, a default is used. Server configuration may force this value into a certain range
+
+This method can be used to retrieve session result for signature from MID.
+
+This is a long poll method, meaning it might not return until a timeout expires. Caller can tune the request parameters inside the bounds set by service operator by using the <strong>timeoutMs</strong> query parameter.
+
+Example:
+
+BASE/signature/session/93de76af-68c1-4b55-91f7-3dad52b3115d?timeoutMs=10000
 
 ### <span class="numhead-number">4.4.1\.</span> Preconditions
 
@@ -1712,7 +1584,15 @@ _`}`_
 
 </div>
 
+<strong>Query parameter</strong> timeoutMs Request long poll timeout value in milliseconds. If not provided, a default is used. Server configuration may force this value into a certain range
+
 This method can be used to retrieve session result for authentication from MID.
+
+This is a long poll method, meaning it might not return until a timeout expires. Caller can tune the request parameters inside the bounds set by service operator by using the <strong>timeoutMs</strong> query parameter.
+
+Example:
+
+BASE/authentication/session/93de76af-68c1-4b55-91f7-3dad52b3115d?timeoutMs=10000
 
 ### <span class="numhead-number">4.6.1\.</span> Preconditions
 

--- a/README.md
+++ b/README.md
@@ -216,8 +216,6 @@ This method retrieves the signing certificate.
 
 This method is necessary for *AdES-styled digital signatures which require knowledge of the certificate before creating the signature.
 
-**NB!** This method will be updated during February 2018.  Please come back for updated version soon.
-
 ### <span class="numhead-number">4.1.1\.</span> Preconditions 
 
 *   User identified in the request (by relyingPartyName, relyingPartyUUID and IP-address)

--- a/README.md
+++ b/README.md
@@ -29,36 +29,33 @@
         *   [4.1.3\. Request parameters](#413-request-parameters)
         *   [4.1.4\. Example request](#414-example-request)
         *   [4.1.5\. Example response](#415-example-response)
-        *   [4.1.6\. Error conditions](#416-error-conditions)
-    *   [4.2\. Certificate request status](#42-certificate-request-status)
+        *   [4.1.6\. Response structure](#416-response-structure)
+        *   [4.1.7\. Error conditions](#417-error-conditions)
+        *   [4.1.8\. Possible result values](#418-possible-result-values)
+    *   [4.2\. Signature request](#42-signature-request)
         *   [4.2.1\. Preconditions](#421-preconditions)
         *   [4.2.2\. Postconditions](#422-postconditions)
-        *   [4.2.3\. Response structure ](#423-response-structure)
-        *   [4.2.4\. Error codes](#424-error-codes)
-    *   [4.3\. Signature request](#43-signature-request)
+        *   [4.2.3\. Request parameters](#423-request-parameters)
+        *   [4.2.4\. Example request](#424-example-request)
+        *   [4.2.5\. Example response](#425-example-response)
+        *   [4.2.6\. Error codes](#426-error-codes)
+    *   [4.3\. Signature status](#43-signature-status)
         *   [4.3.1\. Preconditions](#431-preconditions)
         *   [4.3.2\. Postconditions](#432-postconditions)
-        *   [4.3.3\. Request parameters](#433-request-parameters)
-        *   [4.3.4\. Example request](#434-example-request)
-        *   [4.3.5\. Example response](#435-example-response)
-        *   [4.3.6\. Error codes](#436-error-codes)
-    *   [4.4\. Signature status](#44-signature-status)
+        *   [4.3.3\. Response structure ](#433-response-structure)
+        *   [4.3.4\. Error codes](#434-error-codes)
+    *   [4.4\. Authentication request](#44-authentication-request)
         *   [4.4.1\. Preconditions](#441-preconditions)
-        *   [4.4.2\. Postconditions](#442-postconditions)
-        *   [4.4.3\. Response structure ](#443-response-structure)
-        *   [4.4.4\. Error codes](#444-error-codes)
-    *   [4.5\. Authentication request](#45-authentication-request)
+        *   [4.4.2\. Preconditions](#442-preconditions)
+        *   [4.4.3\. Authentication request parameters](#443-authentication-request-parameters)
+        *   [4.4.4\. Example request](#444-example-request)
+        *   [4.4.5\. Example response](#445-example-response)
+        *   [4.4.6\. Error codes](#446-error-codes)
+    *   [4.5\.  Authentication status](#45-authentication-status)
         *   [4.5.1\. Preconditions](#451-preconditions)
-        *   [4.5.2\. Preconditions](#452-preconditions)
-        *   [4.5.3\. Authentication request parameters](#453-authentication-request-parameters)
-        *   [4.5.4\. Example request](#454-example-request)
-        *   [4.5.5\. Example response](#455-example-response)
-        *   [4.5.6\. Error codes](#456-error-codes)
-    *   [4.6\.  Authentication status](#46-authentication-status)
-        *   [4.6.1\. Preconditions](#461-preconditions)
-        *   [4.6.2\. Postconditions](#462-postconditions)
-        *   [4.6.3\. Response structure ](#463-response-structure)
-        *   [4.6.4\. Error codes](#464-error-codes)
+        *   [4.5.2\. Postconditions](#452-postconditions)
+        *   [4.5.3\. Response structure ](#453-response-structure)
+        *   [4.5.4\. Error codes](#454-error-codes)
 *   [5\. Session end result codes](#5-session-end-result-codes)
 
 <div>  
@@ -574,7 +571,7 @@ Description
 </div>
 
 
-## <span class="numhead-number">4.3\.</span> Signature request
+## <span class="numhead-number">4.2\.</span> Signature request
 
 <div class="table-wrap">
 
@@ -609,15 +606,15 @@ Description
 
 This method is the main entry point to signing logic.
 
-### <span class="numhead-number">4.3.1\.</span> Preconditions
+### <span class="numhead-number">4.2.1\.</span> Preconditions
 
 *   User identified in the request.
 
-### <span class="numhead-number">4.3.2\.</span> Postconditions
+### <span class="numhead-number">4.2.2\.</span> Postconditions
 
 *   a new session with ID is returned in response. 
 
-### <span class="numhead-number">4.3.3\.</span> <span class="inline-comment-marker" data-ref="54f344ad-e80a-41ba-98cb-8e8d899d26f0">Request parameters</span>
+### <span class="numhead-number">4.2.3\.</span> <span class="inline-comment-marker" data-ref="54f344ad-e80a-41ba-98cb-8e8d899d26f0">Request parameters</span>
 
 <div class="table-wrap">
 
@@ -759,7 +756,7 @@ Description
 
 </div>
 
-### <span class="numhead-number">4.3.4\.</span> Example request
+### <span class="numhead-number">4.2.4\.</span> Example request
 
 <div class="table-wrap">
 
@@ -794,7 +791,7 @@ _`}`_
 
 </div>
 
-### <span class="numhead-number">4.3.5\.</span> Example response
+### <span class="numhead-number">4.2.5\.</span> Example response
 
 <div class="table-wrap">
 
@@ -820,7 +817,7 @@ _`}`_
 
 </div>
 
-### <span class="numhead-number">4.3.6\.</span> Error codes
+### <span class="numhead-number">4.2.6\.</span> Error codes
 
 <div class="table-wrap">
 
@@ -927,7 +924,7 @@ _`}`_
 
 </div>
 
-## <span class="numhead-number">4.4\.</span> Signature status
+## <span class="numhead-number">4.3\.</span> Signature status
 
 <div class="table-wrap">
 
@@ -967,15 +964,15 @@ Example:
 
 BASE/signature/session/93de76af-68c1-4b55-91f7-3dad52b3115d?timeoutMs=10000
 
-### <span class="numhead-number">4.4.1\.</span> Preconditions
+### <span class="numhead-number">4.3.1\.</span> Preconditions
 
 *   Session is present in the system and the request is either running or has been completed less than x minutes ago. 
 
-### <span class="numhead-number">4.4.2\.</span> Postconditions
+### <span class="numhead-number">4.3.2\.</span> Postconditions
 
 *   Request result has been returned to user. 
 
-### <span class="numhead-number">4.4.3\.</span> Response structure 
+### <span class="numhead-number">4.3.3\.</span> Response structure 
 
 <div class="table-wrap">
 
@@ -1140,7 +1137,7 @@ _`}`_
 
 </div>
 
-### <span class="numhead-number">4.4.4\.</span> Error codes
+### <span class="numhead-number">4.3.4\.</span> Error codes
 
 <div class="table-wrap">
 
@@ -1216,7 +1213,7 @@ _`}`_
 
 </div>
 
-## <span class="numhead-number">4.5\.</span> Authentication request
+## <span class="numhead-number">4.4\.</span> Authentication request
 
 <div class="table-wrap">
 
@@ -1248,15 +1245,15 @@ _`}`_
 
 This method is the main entry point to authentication logic.
 
-### <span class="numhead-number">4.5.1\.</span> Preconditions
+### <span class="numhead-number">4.4.1\.</span> Preconditions
 
 *   User identified in the request. 
 
-### <span class="numhead-number">4.5.2\.</span> Preconditions
+### <span class="numhead-number">4.4.2\.</span> Preconditions
 
 *   New session has been created in the system and its ID returned in response. 
 
-### <span class="numhead-number">4.5.3\.</span> Authentication request parameters
+### <span class="numhead-number">4.4.3\.</span> Authentication request parameters
 
 <div class="table-wrap">
 
@@ -1398,7 +1395,7 @@ Description
 
 </div>
 
-### <span class="numhead-number">4.5.4\.</span> Example request
+### <span class="numhead-number">4.4.4\.</span> Example request
 
 <div class="table-wrap">
 
@@ -1433,7 +1430,7 @@ _`}`_
 
 </div>
 
-### <span class="numhead-number">4.5.5\.</span> Example response
+### <span class="numhead-number">4.4.5\.</span> Example response
 
 <div class="table-wrap">
 
@@ -1459,7 +1456,7 @@ _`}`_
 
 </div>
 
-### <span class="numhead-number">4.5.6\.</span> Error codes
+### <span class="numhead-number">4.4.6\.</span> Error codes
 
 <div class="table-wrap">
 
@@ -1554,7 +1551,7 @@ _`}`_
 
 </div>
 
-## <span class="numhead-number">4.6\.</span> Authentication status
+## <span class="numhead-number">4.5\.</span> Authentication status
 
 <div class="table-wrap">
 
@@ -1594,15 +1591,15 @@ Example:
 
 BASE/authentication/session/93de76af-68c1-4b55-91f7-3dad52b3115d?timeoutMs=10000
 
-### <span class="numhead-number">4.6.1\.</span> Preconditions
+### <span class="numhead-number">4.5.1\.</span> Preconditions
 
 *   Session is present in the system and the request is either running or has been completed less than x minutes ago. 
 
-### <span class="numhead-number">4.6.2\.</span> Postconditions
+### <span class="numhead-number">4.5.2\.</span> Postconditions
 
 *   Request result has been returned to user. 
 
-### <span class="numhead-number">4.6.3\.</span> Response structure 
+### <span class="numhead-number">4.5.3\.</span> Response structure 
 
 <div class="table-wrap">
 
@@ -1780,7 +1777,7 @@ _`}`_
 
 </div>
 
-### <span class="numhead-number">4.6.4\.</span> Error codes
+### <span class="numhead-number">4.5.4\.</span> Error codes
 
 <div class="table-wrap">
 


### PR DESCRIPTION
* Certificate request now returns immediately and doesn't create a session - updated documentation to reflect that
* For signature and authentication status request it is now possible to use an optional query parameter to send a prefered timeout value for long poll - updated documentation to reflect that
* fixed paragraph numbering